### PR TITLE
Fix Issue #7 (resource starvation/preempting)

### DIFF
--- a/pungi-create-install/fspin-27-x86-64-pungi
+++ b/pungi-create-install/fspin-27-x86-64-pungi
@@ -7,7 +7,7 @@ ZONE="us-central1-f"
 
 # Create instance to run pungi
 echo "Starting pungi run on ${INSTANCE_NAME} using base image ${LATEST_IMAGE}..."
-gcloud compute instances create ${INSTANCE_NAME} --zone ${ZONE} --image ${LATEST_IMAGE} --boot-disk-size 50GB --boot-disk-type pd-ssd --machine-type n1-standard-16 --preemptible --scopes storage-rw && \
+gcloud compute instances create ${INSTANCE_NAME} --zone ${ZONE} --image ${LATEST_IMAGE} --boot-disk-size 50GB --boot-disk-type pd-ssd --machine-type n1-standard-8 --preemptible --scopes storage-rw && \
 
 # Prep the kickstart
 gcloud compute ssh ${INSTANCE_NAME} --zone ${ZONE} --command "pushd /usr/share/spin-kickstarts && sudo sed -i '/%include fedora-repo.ks/d' fedora-live-base.ks && sudo cp /tmp/fspin-snapshot-repo-not-rawhide-with-source.ks fedora-repo-not-rawhide.ks && sudo cp /tmp/all-spins.ks . && ksflatten --config all-spins.ks -o /tmp/flat-all.ks --version F27; popd" && \


### PR DESCRIPTION
This change allows for the pungi builder node to use less extra resources and as such makes it more streamlined with the other nodes, and reduces the risk it will be preempted.  Preempted nodes are starved or paused due to fear that the job(s) running on them may overcommit the available resources allowing other nodes to complete and placing that node in a queue of sorts.

This change will reduce the excess resources on the pungi node from 16 cpus with 60gb ram to 8 cpus and 30gb ram, which is more in line with the other nodes.