### PR TITLE
Implement importing f28 base image.

### DIFF
--- a/builder-update/Dockerfile
+++ b/builder-update/Dockerfile
@@ -23,7 +23,9 @@ RUN set -x \
        && envsubst '${SNAPSHOT_ID}' < "fspin-repo-not-rawhide-with-source.ks" > "fspin-snapshot-repo-not-rawhide-with-source.ks" \
        && envsubst '${SNAPSHOT_ID}' < "fspin-27-x86-64-builder.json" > "fspin-snapshot-27-x86-64-builder.json" \
        && envsubst '${SNAPSHOT_ID}' < "mock-fspin-f27-x86_64.cfg" > "mock-snapshot-fspin-f27-x86_64.cfg" \
+       && envsubst '${SNAPSHOT_ID}' < "fspin-28-x86-64-builder.json" > "fspin-snapshot-28-x86-64-builder.json" \
+       && envsubst '${SNAPSHOT_ID}' < "mock-fspin-f28-x86_64.cfg" > "mock-snapshot-fspin-f28-x86_64.cfg" \
        && echo "export SNAPSHOT_ID=${SNAPSHOT_ID}" > snapshot_id \
        && echo "export SPIN_ID=`echo ${SNAPSHOT_ID}|awk -F- '{print $1$2$3}'`" >> snapshot_id
 
-ENTRYPOINT /bin/packer build -force fspin-snapshot-27-x86-64-builder.json
+ENTRYPOINT /opt/fspin-packer-snapshot-builder

--- a/builder-update/fspin-27-x86-64-builder.json
+++ b/builder-update/fspin-27-x86-64-builder.json
@@ -3,7 +3,7 @@
     {
       "type": "googlecompute",
       "project_id": "fspin-199819",
-      "source_image": "fspin-27-1-6-x86-64",
+      "source_image_family": "fspin-27",
       "ssh_username": "packer",
       "zone": "us-central1-f",
       "name": "fspin-27-x86-64-${SNAPSHOT_ID}",

--- a/builder-update/fspin-28-x86-64-builder.json
+++ b/builder-update/fspin-28-x86-64-builder.json
@@ -1,0 +1,57 @@
+{
+  "builders": [
+    {
+      "type": "googlecompute",
+      "project_id": "fspin-199819",
+      "source_image_family": "fspin-28",
+      "ssh_username": "packer",
+      "zone": "us-central1-f",
+      "name": "fspin-28-x86-64-${SNAPSHOT_ID}",
+      "image_name": "fspin-28-x86-64-${SNAPSHOT_ID}",
+      "disk_type": "pd-ssd",
+      "preemptible": "true",
+      "machine_type": "n1-standard-4"
+    }
+  ],
+  "provisioners": [
+    {
+     "type": "file",
+     "source": "/opt/fspin-snapshot.repo",
+     "destination": "/tmp/fspin.repo"
+    },
+    {
+     "type": "file",
+     "source": "/opt/mock-snapshot-fspin-f28-x86_64.cfg",
+     "destination": "/tmp/mock-snapshot-fspin-f28-x86_64.cfg"
+    },
+    {
+      "type": "shell",
+      "inline": [
+	"sudo dnf -y config-manager --set-disabled '*'",
+	"sudo cp /tmp/fspin.repo /etc/yum.repos.d/",
+	"sudo dnf -y config-manager --set-enabled 'fspin-*' google-cloud-sdk",
+	"sudo dnf -y install vim-enhanced mock transmission-cli",
+	"sudo dnf -y install lorax-lmc-novirt pykickstart spin-kickstarts kernel-modules",
+        "sudo dnf -y install pungi pungi-legacy yum kobo python2-productmd python-lockfile createrepo python2-kickstart repoview",
+        "sudo dnf -y update",
+	"sudo sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config",
+	"sudo cp /tmp/mock-snapshot-fspin-f28-x86_64.cfg /etc/mock/fspin-snapshot-28-x86_64.cfg"
+      ]
+    },
+    {
+     "type": "file",
+     "source": "/opt/fspin-snapshot-repo-not-rawhide-with-source.ks",
+     "destination": "/tmp/fspin-snapshot-repo-not-rawhide-with-source.ks"
+    },
+    {
+     "type": "file",
+     "source": "/opt/all-spins.ks",
+     "destination": "/tmp/all-spins.ks"
+    },
+    {
+     "type": "file",
+     "source": "/opt/snapshot_id",
+     "destination": "/tmp/snapshot_id"
+    }
+  ]
+}

--- a/builder-update/fspin-packer-snapshot-builder
+++ b/builder-update/fspin-packer-snapshot-builder
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Build updated GCE images with packer
+/bin/packer build -force /opt/fspin-snapshot-27-x86-64-builder.json && \
+/bin/packer build -force /opt/fspin-snapshot-28-x86-64-builder.json

--- a/builder-update/mock-fspin-f28-x86_64.cfg
+++ b/builder-update/mock-fspin-f28-x86_64.cfg
@@ -1,0 +1,38 @@
+config_opts['root'] = 'fspin-snapshot-28-x86_64'
+config_opts['target_arch'] = 'x86_64'
+config_opts['legal_host_arches'] = ('x86_64',)
+config_opts['chroot_setup_cmd'] = 'install @buildsys-build'
+config_opts['dist'] = 'fc28'
+config_opts['extra_chroot_dirs'] = [ '/run/lock', ]
+config_opts['releasever'] = '28'
+config_opts['package_manager'] = 'dnf'
+config_opts['rpmbuild_networking'] = True
+config_opts['yum.conf'] = """
+[main]
+keepcache=1
+debuglevel=2
+reposdir=/dev/null
+logfile=/var/log/yum.log
+retries=20
+obsoletes=1
+gpgcheck=0
+assumeyes=1
+syslog_ident=mock
+syslog_device=
+install_weak_deps=0
+metadata_expire=0
+mdpolicy=group:primary
+best=1
+
+[fspin-fedora]
+name=fspin-fedora-${SNAPSHOT_ID}
+baseurl=http://repo.fspin.org/${SNAPSHOT_ID}/releases/$releasever/Everything/$basearch/os/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+
+[fspin-updates]
+name=fspin-updates-${SNAPSHOT_ID}
+baseurl=http://repo.fspin.org/${SNAPSHOT_ID}/updates/$releasever/$basearch/
+gpgcheck=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-$releasever-$basearch
+"""

--- a/cloud-image-import/fspin-import-image
+++ b/cloud-image-import/fspin-import-image
@@ -21,7 +21,7 @@ gcloud compute images create fspin-27-${IMPORT_TIME} \
     --family fspin-27 && \
 
 # Not working with kernel < 4.16.6
-# Needs ealier json-c injected into image for google components during the import process
+# Needs earlier json-c injected into image for google components during the import process
 echo "Importing F28..." && \
 # launch latest f27 image, download f28 image, decompress, mount, inject compat-json-c, unmount, pull raw image result
 gcloud compute instances create f28-inject-json-c \

--- a/cloud-image-import/fspin-import-image
+++ b/cloud-image-import/fspin-import-image
@@ -1,17 +1,50 @@
 #!/bin/bash
-# Import upstream cloud base images into GCE
+# Import upstream cloud base images into GCE for custom image family
+set -x
+IMPORT_TIME=$(date +%s)
+ZONE='us-central1-f'
+PROJECT='fspin-199819'
+COMPAT_JSON_C='https://jsteffan.fedorapeople.org/compat-json-c/compat-json-c-0.12.1-5.fc28.x86_64.rpm'
 
-echo "Removing old images..."
-gcloud compute images delete fspin-27-1-6-x86-64 --quiet
-gcloud compute images delete fspin-28-1-1-x86-64 --quiet
+gcloud config set project ${PROJECT}
+gcloud config set compute/zone ${ZONE}
 
-echo "Importing F27..."
+echo "Importing F27..." && \
 wget https://download.fedoraproject.org/pub/fedora/linux/releases/27/CloudImages/x86_64/images/Fedora-Cloud-Base-27-1.6.x86_64.raw.xz && \
 unxz Fedora-Cloud-Base-27-1.6.x86_64.raw.xz && \
-gcloud --quiet beta compute images import fspin-27-1-6-x86-64 --source-file Fedora-Cloud-Base-27-1.6.x86_64.raw --os centos-7
+gcloud --quiet beta compute images import fspin-27-1-6-x86-64-${IMPORT_TIME} \
+    --source-file Fedora-Cloud-Base-27-1.6.x86_64.raw \
+    --os centos-7 && \
+gcloud compute images create fspin-27-${IMPORT_TIME} \
+    --source-image fspin-27-1-6-x86-64-${IMPORT_TIME} \
+    --source-image-project ${PROJECT} \
+    --family fspin-27 && \
 
-# Not working with kernel > 4.16.3
-#echo "Importing F28..." && \
-#wget https://download.fedoraproject.org/pub/fedora/linux/releases/28/Cloud/x86_64/images/Fedora-Cloud-Base-28-1.1.x86_64.raw.xz && \
-#unxz Fedora-Cloud-Base-28-1.1.x86_64.raw.xz && \
-#gcloud --quiet beta compute images import fspin-28-1-1-x86-64 --source-file Fedora-Cloud-Base-28-1.1.x86_64.raw --os centos-7
+# Not working with kernel < 4.16.6
+# Needs ealier json-c injected into image for google components during the import process
+echo "Importing F28..." && \
+# launch latest f27 image, download f28 image, decompress, mount, inject compat-json-c, unmount, pull raw image result
+gcloud compute instances create f28-inject-json-c \
+    --image-family fspin-27 \
+    --boot-disk-size 50GB \
+    --boot-disk-type pd-ssd \
+    --machine-type n1-standard-4 && \
+gcloud compute ssh f28-inject-json-c \
+    --command "sudo bash -c 'dnf -y install wget xz && wget https://kojipkgs.fedoraproject.org/packages/Fedora-Cloud-Base/28/20180507.0/images/Fedora-Cloud-Base-28-20180507.0.x86_64.raw.xz && unxz Fedora-Cloud-Base-28-20180507.0.x86_64.raw.xz'" && \
+gcloud compute ssh f28-inject-json-c \
+    --command "sudo bash -c 'dnf -y install libguestfs-tools && mkdir -p /fcb && LIBGUESTFS_BACKEND=direct guestmount -a Fedora-Cloud-Base-28-20180507.0.x86_64.raw -i /fcb'" && \
+gcloud compute ssh f28-inject-json-c \
+    --command "sudo bash -c 'rpm -Uvh --root /fcb ${COMPAT_JSON_C}'" && \
+gcloud compute ssh f28-inject-json-c \
+    --command "sudo bash -c 'guestunmount /fcb && sleep 60'" && \
+gcloud compute scp f28-inject-json-c:Fedora-Cloud-Base-28-20180507.0.x86_64.raw . && \
+gcloud -q compute instances delete f28-inject-json-c --delete-disks all && \
+
+# run import with injected raw disk
+gcloud --quiet beta compute images import fspin-28-1-1-20180507-x86-64-${IMPORT_TIME} \
+    --source-file Fedora-Cloud-Base-28-20180507.0.x86_64.raw \
+    --os centos-7 && \
+gcloud compute images create fspin-28-${IMPORT_TIME} \
+    --source-image fspin-28-1-1-20180507-x86-64-${IMPORT_TIME} \
+    --source-image-project ${PROJECT} \
+    --family fspin-28


### PR DESCRIPTION
- Use image family to define the latest base image so we are not deleting base images
- Use f27 to inject custom compat-json-c package for google tools into f28 upstream cloud base image
- Use cloud base build from koji that has kernel 4.16.6 that correctly boots on GCE