### PR TITLE
Clean Up Builds in the Publish Job

### DIFF
--- a/k8s/fspin-publish-job.yaml
+++ b/k8s/fspin-publish-job.yaml
@@ -8,4 +8,5 @@ spec:
       containers:
       - name: fspin-publish
         image: gcr.io/fspin-199819/fspin-publish
-      restartPolicy: Never
+      restartPolicy: OnFailure
+  backoffLimit: 1

--- a/publisher/fspin-publish
+++ b/publisher/fspin-publish
@@ -27,4 +27,4 @@ echo "Cleaning out old releases and builds..." && \
 gsutil rm -r gs://build-results.fspin.org/{live,source,releases} && \
 echo "Publishing ${RELEASE_ID} to ${RESULTS_LOCATION}" && \
 gsutil mv ${TMP_LOCATION} ${RESULTS_LOCATION} && \
-echo "SUCCESS: Results located at ${RESULTS_LOCATION}/${RELEASE_ID}/"
+echo "SUCCESS: Results located at ${RESULTS_LOCATION}${RELEASE_ID}/"

--- a/publisher/fspin-publish
+++ b/publisher/fspin-publish
@@ -1,9 +1,13 @@
 #!/bin/bash
-# Create a release candidate and push to GCS for the mirrors
+# Publish a Build
+# - Clean out old releases
+# - Create a release candidate for the mirrors to sync
+# - Clean out all old builds
 set -x
 source /opt/release_id && \
 RELEASE_STRING=`echo ${RELEASE_ID}|sed 's/-//g'` && \
-RESULTS_LOCATION="gs://build-results.fspin.org/releases/${RELEASE_ID}/" && \
+RESULTS_LOCATION="gs://build-results.fspin.org/releases/" && \
+TMP_LOCATION="gs://build-results.fspin.org/${RELEASE_ID}/" && \
 pushd ${RELEASE_ID} && \
 echo "Downloading checksums for ${RELEASE_ID}..." && \
 gsutil cp gs://build-results.fspin.org/*/*/CHECKSUM512-*${RELEASE_STRING}* . && \
@@ -13,10 +17,14 @@ echo "Downloading tracker hashfiles for ${RELEASE_ID}..." && \
 gsutil cp gs://build-results.fspin.org/*/*/*${RELEASE_STRING}*-torrenthash . && \
 echo "Creating tracker hashfile for ${RELEASE_ID}..." && \
 cat *-torrenthash >> torrenthashes-${RELEASE_STRING} && \
-echo "Publishing ${RELEASE_ID} to ${RESULTS_LOCATION}..." && \
-gsutil cp CHECKSUM512-${RELEASE_STRING} ${RESULTS_LOCATION} && \
-gsutil cp torrenthashes-${RELEASE_STRING} ${RESULTS_LOCATION} && \
-gsutil cp gs://build-results.fspin.org/{live,installer}/*${RELEASE_ID}*/*.iso ${RESULTS_LOCATION} && \
-gsutil cp gs://build-results.fspin.org/live/*${RELEASE_ID}*/*.torrent ${RESULTS_LOCATION} && \
-gsutil cp README.md ${RESULTS_LOCATION} && \
-echo "SUCCESS: Results located at ${RESULTS_LOCATION}"
+echo "Preparing ${RELEASE_ID} in ${TMP_LOCATION}..." && \
+gsutil cp CHECKSUM512-${RELEASE_STRING} ${TMP_LOCATION} && \
+gsutil cp torrenthashes-${RELEASE_STRING} ${TMP_LOCATION} && \
+gsutil mv gs://build-results.fspin.org/{live,source}/*${RELEASE_ID}*/*.iso ${TMP_LOCATION} && \
+gsutil mv gs://build-results.fspin.org/live/*${RELEASE_ID}*/*.torrent ${TMP_LOCATION} && \
+gsutil cp README.md ${TMP_LOCATION} && \
+echo "Cleaning out old releases and builds..." && \
+gsutil rm -r gs://build-results.fspin.org/{live,source,releases} && \
+echo "Publishing ${RELEASE_ID} to ${RESULTS_LOCATION}" && \
+gsutil mv ${TMP_LOCATION} ${RESULTS_LOCATION} && \
+echo "SUCCESS: Results located at ${RESULTS_LOCATION}/${RELEASE_ID}/"

--- a/pungi-create-source/fspin-x86-64-pungi
+++ b/pungi-create-source/fspin-x86-64-pungi
@@ -3,7 +3,7 @@
 set -x
 LATEST_IMAGE=$(gcloud compute images list --filter="name~fspin-${RELEASE}-x86-64" --sort-by="~creationTimestamp" --limit=1 --format="json(NAME)"|jq -r .[].name)
 INSTANCE_NAME="${LATEST_IMAGE}-pungi-$(cat /proc/sys/kernel/random/uuid|awk -F- '{print $5}')"
-RESULTS_LOCATION="gs://build-results.fspin.org/installer/${INSTANCE_NAME}/"
+RESULTS_LOCATION="gs://build-results.fspin.org/source/${INSTANCE_NAME}/"
 ZONE="us-central1-f"
 
 # Create instance to run pungi


### PR DESCRIPTION
Use the publish job to:
 - Clean out old releases
- Create a release candidate for the mirrors to sync
- Clean out all old builds
