### PR TITLE
Add patches for kickstart changes in F29

### DIFF
--- a/builder-update/fspin-29-x86-64-builder.json
+++ b/builder-update/fspin-29-x86-64-builder.json
@@ -25,17 +25,23 @@
      "destination": "/tmp/mock-snapshot-fspin-f29-x86_64.cfg"
     },
     {
+     "type": "file",
+     "source": "/opt/fspin-kickstart-patches-20181121.patch",
+     "destination": "/tmp/fspin-kickstart-patches-20181121.patch"
+    },
+    {
       "type": "shell",
       "inline": [
 	"sudo dnf -y config-manager --set-disabled '*'",
 	"sudo cp /tmp/fspin.repo /etc/yum.repos.d/",
 	"sudo dnf -y config-manager --set-enabled 'fspin-*' google-cloud-sdk",
-	"sudo dnf -y install vim-enhanced mock transmission-cli",
+	"sudo dnf -y install vim-enhanced mock transmission-cli patch",
 	"sudo dnf -y install lorax-lmc-novirt pykickstart spin-kickstarts kernel-modules",
         "sudo dnf -y install pungi pungi-legacy yum python2-kobo python2-productmd python2-lockfile createrepo python2-kickstart repoview https://jsteffan.fedorapeople.org/python2-createrepo/python2-createrepo-0.10.3-16.fc29.noarch.rpm",
         "sudo dnf -y update",
 	"sudo sed -i 's/SELINUX=enforcing/SELINUX=permissive/g' /etc/selinux/config",
-	"sudo cp /tmp/mock-snapshot-fspin-f29-x86_64.cfg /etc/mock/fspin-snapshot-x86_64.cfg"
+	"sudo cp /tmp/mock-snapshot-fspin-f29-x86_64.cfg /etc/mock/fspin-snapshot-x86_64.cfg",
+	"sudo cp /tmp/fspin-kickstart-patches-20181121.patch /usr/share/spin-kickstarts/fspin-kickstart-patches-20181121.patch"
       ]
     },
     {

--- a/builder-update/fspin-kickstart-patches-20181121.patch
+++ b/builder-update/fspin-kickstart-patches-20181121.patch
@@ -96,3 +96,16 @@ diff -up ./fedora-xfce-common.ks.orig ./fedora-xfce-common.ks
 +kernel-devel
 +
  %end
+diff --git ./fedora-live-cinnamon.ks.orig ./fedora-live-cinnamon.ks
+index 6aab086..f629c06 100644
+--- ./fedora-live-cinnamon.ks.orig
++++ ./fedora-live-cinnamon.ks
+@@ -9,7 +9,7 @@
+ %include fedora-live-base.ks
+ %include fedora-cinnamon-common.ks
+
+-part / --size=6144
++part / --size=6500
+
+ %post
+ # cinnamon configuration

--- a/builder-update/fspin-kickstart-patches-20181121.patch
+++ b/builder-update/fspin-kickstart-patches-20181121.patch
@@ -1,0 +1,98 @@
+diff -up ./fedora-cinnamon-common.ks.orig ./fedora-cinnamon-common.ks
+--- ./fedora-cinnamon-common.ks.orig	2018-11-22 04:38:37.283575302 +0000
++++ ./fedora-cinnamon-common.ks	2018-11-22 04:42:19.734422545 +0000
+@@ -16,4 +16,7 @@ parole
+ # extra backgrounds
+ f29-backgrounds-extras-gnome
+ 
++# fspin custom
++kernel-devel
++
+ %end
+diff -up ./fedora-kde-common.ks.orig ./fedora-kde-common.ks
+--- ./fedora-kde-common.ks.orig	2018-11-22 04:39:14.021534172 +0000
++++ ./fedora-kde-common.ks	2018-11-22 04:42:35.250670711 +0000
+@@ -55,4 +55,7 @@ mediawriter
+ 
+ ## avoid serious bugs by omitting broken stuff
+ 
++# fspin custom
++kernel-devel
++
+ %end
+diff -up ./fedora-live-mate_compiz.ks.orig ./fedora-live-mate_compiz.ks
+--- ./fedora-live-mate_compiz.ks.orig	2018-11-22 04:46:20.678814527 +0000
++++ ./fedora-live-mate_compiz.ks	2018-11-22 04:46:43.793675530 +0000
+@@ -7,7 +7,7 @@
+ %include fedora-mate-common.ks
+ %include fedora-live-minimization.ks
+ 
+-part / --size 6144
++part / --size 6500
+ 
+ %post
+ cat >> /etc/rc.d/init.d/livesys << EOF
+diff -up ./fedora-lxde-common.ks.orig ./fedora-lxde-common.ks
+--- ./fedora-lxde-common.ks.orig	2018-11-22 04:39:22.728236149 +0000
++++ ./fedora-lxde-common.ks	2018-11-22 04:42:44.012375537 +0000
+@@ -59,5 +59,8 @@ metacity
+ -policycoreutils-gui
+ -gnome-disk-utility
+ 
++# fspin custom
++kernel-devel
++
+ %end
+ 
+diff -up ./fedora-lxqt-common.ks.orig ./fedora-lxqt-common.ks
+--- ./fedora-lxqt-common.ks.orig	2018-11-22 04:39:30.716880233 +0000
++++ ./fedora-lxqt-common.ks	2018-11-22 04:49:19.456219243 +0000
+@@ -45,12 +45,14 @@ wqy-microhei-fonts          # a compact
+ -@input-methods
+ -scim*
+ -m17n*
+--ibus*
+ -iok
+ 
+ # Fix https://bugzilla.redhat.com/show_bug.cgi?id=1429132
+ # Why is this not pulled in by anaconda???
+ storaged
+ 
++# fspin custom
++kernel-devel
++
+ %end
+ 
+diff -up ./fedora-mate-common.ks.orig ./fedora-mate-common.ks
+--- ./fedora-mate-common.ks.orig	2018-11-22 04:39:51.366545141 +0000
++++ ./fedora-mate-common.ks	2018-11-22 04:43:00.957738672 +0000
+@@ -51,4 +51,7 @@ nss-mdns
+ # Legacy cmdline things we don't want
+ -telnet
+ 
++# fspin custom
++kernel-devel
++
+ %end
+diff -up ./fedora-workstation-common.ks.orig ./fedora-workstation-common.ks
+--- ./fedora-workstation-common.ks.orig	2018-11-22 04:40:00.831308245 +0000
++++ ./fedora-workstation-common.ks	2018-11-22 04:43:07.157237373 +0000
+@@ -24,4 +24,7 @@
+ -gfs2-utils
+ -reiserfs-utils
+ 
++# fspin custom
++kernel-devel
++
+ %end
+diff -up ./fedora-xfce-common.ks.orig ./fedora-xfce-common.ks
+--- ./fedora-xfce-common.ks.orig	2018-11-22 04:40:06.984804374 +0000
++++ ./fedora-xfce-common.ks	2018-11-22 04:43:16.215966079 +0000
+@@ -39,4 +39,7 @@ system-config-printer
+ -aspell-*                   # dictionaries are big
+ -xfce4-sensors-plugin
+ 
++# fspin custom
++kernel-devel
++
+ %end

--- a/lmc-create-spin/fspin-x86-64-livemedia-creator
+++ b/lmc-create-spin/fspin-x86-64-livemedia-creator
@@ -2,7 +2,7 @@
 # Run spin snippets in the latest GCE fspin image for ${RELEASE} x86_64
 set -x
 LATEST_IMAGE=$(gcloud compute images list --filter="name~fspin-${RELEASE}-x86-64" --sort-by="~creationTimestamp" --limit=1 --format="json(NAME)"|jq -r .[].name)
-INSTANCE_NAME="${LATEST_IMAGE}-lmc-$(cat /proc/sys/kernel/random/uuid|awk -F- '{print $5}')"
+INSTANCE_NAME="${LATEST_IMAGE}-lmc-$(cat /proc/sys/kernel/random/uuid|awk -F- '{print $1}')-${TARGET}"
 RESULTS_LOCATION="gs://build-results.fspin.org/live/${INSTANCE_NAME}/"
 ZONE="us-west2-a"
 BUILD_SCRIPT="fspin-x86-64-${TARGET}"

--- a/lmc-create-spin/fspin-x86-64-template
+++ b/lmc-create-spin/fspin-x86-64-template
@@ -5,6 +5,7 @@ source /tmp/snapshot_id && \
 export SPIN_SHORT_NAME=`echo $SPIN_NAME|cut -c1-4|awk '{print toupper($0)}'` && \
 pushd /usr/share/spin-kickstarts && \
 \cp -f /tmp/fspin-snapshot-repo-not-rawhide-with-source.ks fedora-repo-not-rawhide.ks && \
+patch -p0 < fspin-kickstart-patches-20181121.patch && \
 mv fedora-live-mate_compiz.ks fedora-live-mate-compiz.ks && \
 ksflatten --config fedora-live-${SPIN_NAME}.ks -o flat-fedora-live-${SPIN_NAME}.ks --version F${RELEASE} && \
 mkfs.ext4 -F /dev/nvme0n1 && \


### PR DESCRIPTION
 - Add kernel-devel to all spins
 - Expand loop device for MATE
 - Add ibus for LXQT
 - Rename LMC GCP instances with the spin name for easier debug