### PR TITLE
Update repo deployment to be able to detect failures.

### DIFF
--- a/k8s/repo-fspin-org-deployment.yaml
+++ b/k8s/repo-fspin-org-deployment.yaml
@@ -21,6 +21,20 @@ spec:
         - mountPath: /mirror
           name: fspin-mirror-storage
           readOnly: true
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 5
+          timeoutSeconds: 1
+          periodSeconds: 15
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 80
+          initialDelaySeconds: 15
+          timeoutSeconds: 1
+          periodSeconds: 15
       volumes:
       - name: fspin-mirror-storage
         gcePersistentDisk:


### PR DESCRIPTION
The repo failed to start after doing a snapshot. This helps address that failure.