### PR TITLE
Reduce Amount of Retries for Spins

### DIFF
--- a/jobs/run-f29-cinnamon.yaml
+++ b/jobs/run-f29-cinnamon.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     jobgroup: lmc-spinner
 spec:
-  backoffLimit: 60
+  backoffLimit: 10
   template:
     metadata:
       name: fspin-f29-cinnamon

--- a/jobs/run-f29-kde.yaml
+++ b/jobs/run-f29-kde.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     jobgroup: lmc-spinner
 spec:
-  backoffLimit: 60
+  backoffLimit: 10
   template:
     metadata:
       name: fspin-f29-kde

--- a/jobs/run-f29-lxde.yaml
+++ b/jobs/run-f29-lxde.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     jobgroup: lmc-spinner
 spec:
-  backoffLimit: 60
+  backoffLimit: 10
   template:
     metadata:
       name: fspin-f29-lxde

--- a/jobs/run-f29-lxqt.yaml
+++ b/jobs/run-f29-lxqt.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     jobgroup: lmc-spinner
 spec:
-  backoffLimit: 60
+  backoffLimit: 10
   template:
     metadata:
       name: fspin-f29-lxqt

--- a/jobs/run-f29-mate-compiz.yaml
+++ b/jobs/run-f29-mate-compiz.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     jobgroup: lmc-spinner
 spec:
-  backoffLimit: 60
+  backoffLimit: 10
   template:
     metadata:
       name: fspin-f29-mate-compiz

--- a/jobs/run-f29-soas.yaml
+++ b/jobs/run-f29-soas.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     jobgroup: lmc-spinner
 spec:
-  backoffLimit: 60
+  backoffLimit: 10
   template:
     metadata:
       name: fspin-f29-soas

--- a/jobs/run-f29-source.yaml
+++ b/jobs/run-f29-source.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     jobgroup: source-spinner
 spec:
-  backoffLimit: 60
+  backoffLimit: 10
   template:
     metadata:
       name: fspin-f29-source

--- a/jobs/run-f29-workstation.yaml
+++ b/jobs/run-f29-workstation.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     jobgroup: lmc-spinner
 spec:
-  backoffLimit: 60
+  backoffLimit: 10
   template:
     metadata:
       name: fspin-f29-workstation

--- a/jobs/run-f29-xfce.yaml
+++ b/jobs/run-f29-xfce.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     jobgroup: lmc-spinner
 spec:
-  backoffLimit: 60
+  backoffLimit: 10
   template:
     metadata:
       name: fspin-f29-xfce


### PR DESCRIPTION
 - Reduce the job backoff for spins from 60 to 10

We've had a recent spin that ran for 60 times and it was not going to complete. Fail faster to give the operator better feedback that the spin is not going to work.